### PR TITLE
ci(cloc): count and show the number of lines of code in after_script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,5 @@ before_script:
   - yarn build
 script:
   - yarn test
+after_script:
+  - yarn count

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   ],
   "scripts": {
     "build": "lerna run build",
+    "count": "cloc . --vcs=git",
     "precommit": "lint-staged",
     "commit": "git-cz",
     "jest": "jest",
@@ -39,6 +40,7 @@
   "devDependencies": {
     "@goldwasserexchange/jest-config": "^4.4.0",
     "@goldwasserexchange/utils": "^4.4.0",
+    "cloc": "^2.3.4",
     "commitizen": "^3.0.2",
     "cross-env": "^5.2.0",
     "cz-conventional-changelog": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3259,6 +3259,11 @@ cliui@^4.0.0:
     strip-ansi "^4.0.0"
     wrap-ansi "^2.0.0"
 
+cloc@^2.3.4:
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/cloc/-/cloc-2.3.4.tgz#55856ed82068d4ba108af78dee8bff72eb6a4073"
+  integrity sha512-3h2sgA+MMF6zdy09s7WzU1rmNpvm3w5j99M+wtysTgT+JMQESCQqmxMIAHr6aufkXfRg7HjAAFhx9VPi2bZogA==
+
 clone-stats@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/clone-stats/-/clone-stats-0.0.1.tgz#b88f94a82cf38b8791d58046ea4029ad88ca99d1"


### PR DESCRIPTION
Running `yarn count` locally is also available