### PR TITLE
fix(webpack-config): remove unknown css loader option

### DIFF
--- a/packages/build-tools/webpack/webpack-config/module/cssRules/cssLoader.js
+++ b/packages/build-tools/webpack/webpack-config/module/cssRules/cssLoader.js
@@ -15,7 +15,6 @@ module.exports = {
     process.env.NODE_ENV === 'production'
       ? {
         camelCase: true,
-        minimize: true,
       }
       : {},
   ),


### PR DESCRIPTION
Fixes `ValidationError: CSS Loader Invalid Options`  `options should NOT have additional properties` during build.

See https://github.com/webpack-contrib/css-loader/tree/v2.1.1#options
