### PR TITLE
feat(eslint-config-import): disable prefer-default-export

### DIFF
--- a/packages/lint/eslint/eslint-config-import/index.js
+++ b/packages/lint/eslint/eslint-config-import/index.js
@@ -19,6 +19,7 @@ module.exports = {
   rules: {
     'import/newline-after-import': 0,
     'import/no-extraneous-dependencies': ['error', { devDependencies: true }],
+    'import/prefer-default-export': 0, // TODO: enforce later with import/no-default-export, see https://github.com/goldwasserexchange/public/issues/139
   },
   settings: {
     'import/resolver': {


### PR DESCRIPTION
Later we will enforce with `import/no-default-export`, see #139.