### PR TITLE
chore(dep): configure dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,6 @@
+version: 1
+update_configs:
+  - package_manager: javascript
+    directory: /
+    update_schedule: weekly
+    version_requirement_updates: increase_versions

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
 # Goldwasser Exchange Public
 
-[![Greenkeeper badge](https://badges.greenkeeper.io/goldwasserexchange/public.svg)](https://greenkeeper.io/)
-
 Goldwasser Exchange's public packages


### PR DESCRIPTION
We are replacing Greenkeeper by Dependabot.

See https://dependabot.com/docs/config-file/