### PR TITLE
fix(eslint-config-base): update @aws-cdk/cdk to @aws-cdk/core

### DIFF
--- a/packages/lint/eslint-config-base/index.js
+++ b/packages/lint/eslint-config-base/index.js
@@ -20,6 +20,6 @@ module.exports = {
     },
   },
   rules: {
-    ...ifAnyDep('@aws-cdk/cdk', { 'no-new': 0 }, {}),
+    ...ifAnyDep('@aws-cdk/core', { 'no-new': 0 }, {}),
   },
 };


### PR DESCRIPTION
As of v0.36.0 ´@aws-cdk/cdk´ has been renamed to `@aws-cdk/core`.