### PR TITLE
fix(eslint-config-typescript): add support for tsx files

### DIFF
--- a/packages/lint/eslint-config-typescript/index.js
+++ b/packages/lint/eslint-config-typescript/index.js
@@ -19,6 +19,7 @@ module.exports = {
     {
       files: [
         '**/*.ts',
+        '**/*.tsx',
       ],
       rules: { // See https://github.com/typescript-eslint/typescript-eslint/tree/v1.7.0/packages/eslint-plugin/docs/rules
         '@typescript-eslint/adjacent-overload-signatures': 'error',


### PR DESCRIPTION
.tsx files were not supported by the configuration, this files are used in react and other projects to use the jsx syntax