### PR TITLE
chore(oblis-frontend): add json eslint import extension configuration

### DIFF
--- a/packages/lint/eslint-config-import/index.js
+++ b/packages/lint/eslint-config-import/index.js
@@ -27,6 +27,7 @@ module.exports = {
         jsx: 'never',
         ts: 'never',
         tsx: 'never',
+        json: 'always',
       },
     ],
   },


### PR DESCRIPTION
we should always specify the file extension for json files